### PR TITLE
Fix browser agent handling of cookie banners and modal dialogs

### DIFF
--- a/openhands/agenthub/browsing_agent/browsing_agent.py
+++ b/openhands/agenthub/browsing_agent/browsing_agent.py
@@ -40,12 +40,22 @@ def get_error_prefix(last_browser_action: str) -> str:
     return f'IMPORTANT! Last action is incorrect:\n{last_browser_action}\nThink again with the current observation of the page.\n'
 
 
+def has_modal_dialog(axtree_txt: str) -> bool:
+    """Check if the accessibility tree contains a modal dialog (e.g., cookie banner)."""
+    return 'dialog' in axtree_txt and 'modal=True' in axtree_txt
+
+
 def get_system_message(goal: str, action_space: str) -> str:
     return f"""\
 # Instructions
 Review the current state of the page and all other information to find the best
 possible next action to accomplish your goal. Your answer will be interpreted
 and executed by a program, make sure to follow the formatting instructions.
+
+IMPORTANT: If you see a modal dialog (e.g., cookie banner) in the accessibility tree,
+you MUST handle it first before attempting any other actions. Look for buttons with
+text like "Accept", "Accept All", "Continue", etc. in any language. These buttons
+might be marked as hidden=True but should still be clickable.
 
 # Goal:
 {goal}
@@ -80,10 +90,20 @@ def get_prompt(
 # Previous Actions
 {prev_action_str}
 
-Here is an example with chain of thought of a valid action when clicking on a button:
+Here are examples with chain of thought of valid actions:
+
+Example 1 - Clicking a button:
 "
 In order to accomplish my goal I need to click on the button with bid 12
 ```click("12")```
+"
+
+Example 2 - Handling a cookie banner:
+"
+I notice there's a modal dialog for cookie consent that needs to be handled first.
+Looking at the accessibility tree, I can see a button with text 'Accept All' and bid 489.
+I should click this button before proceeding with any other actions.
+```click("489")```
 "
 """.strip()
     if USE_CONCISE_ANSWER:
@@ -193,8 +213,14 @@ class BrowsingAgent(Agent):
                     last_obs.axtree_object,
                     extra_properties=last_obs.extra_element_properties,
                     with_clickable=True,
-                    filter_visible_only=True,
+                    filter_visible_only=False,  # Don't filter visible only to handle hidden cookie banners
                 )
+                # If there's a modal dialog, add a note to the accessibility tree
+                if has_modal_dialog(cur_axtree_txt):
+                    cur_axtree_txt = (
+                        'IMPORTANT: This page has a modal dialog that must be handled first!\n\n'
+                        + cur_axtree_txt
+                    )
             except Exception as e:
                 logger.error(
                     'Error when trying to process the accessibility tree: %s', e

--- a/tests/unit/agenthub/browsing_agent/test_browsing_agent.py
+++ b/tests/unit/agenthub/browsing_agent/test_browsing_agent.py
@@ -1,10 +1,8 @@
 from unittest.mock import MagicMock
 
 from openhands.agenthub.browsing_agent.browsing_agent import (
-    BrowsingAgent,
     has_modal_dialog,
 )
-from openhands.core.config import AgentConfig
 
 
 def test_has_modal_dialog():
@@ -33,11 +31,11 @@ def test_browsing_agent_modal_dialog_handling():
         'choices': [{'message': {'content': 'click("489")'}}]
     }
 
-    # Create a BrowsingAgent instance
-    agent = BrowsingAgent(mock_llm, AgentConfig())
-
     # Import the module-level functions
-    from openhands.agenthub.browsing_agent.browsing_agent import get_system_message, get_prompt
+    from openhands.agenthub.browsing_agent.browsing_agent import (
+        get_prompt,
+        get_system_message,
+    )
 
     # Verify that the system message includes modal dialog handling instructions
     system_msg = get_system_message('test goal', 'test action space')

--- a/tests/unit/agenthub/browsing_agent/test_browsing_agent.py
+++ b/tests/unit/agenthub/browsing_agent/test_browsing_agent.py
@@ -1,0 +1,52 @@
+from unittest.mock import MagicMock
+
+from openhands.agenthub.browsing_agent.browsing_agent import (
+    BrowsingAgent,
+    has_modal_dialog,
+)
+from openhands.core.config import AgentConfig
+
+
+def test_has_modal_dialog():
+    # Test with modal dialog present
+    axtree_txt = """
+    RootWebArea 'Google', focused
+    [346] dialog 'Cookie Consent', clickable, modal=True
+    [489] button 'Accept All', clickable
+    """
+    assert has_modal_dialog(axtree_txt) is True
+
+    # Test without modal dialog
+    axtree_txt = """
+    RootWebArea 'Google', focused
+    [99] combobox 'Search', clickable
+    [260] button 'Google Search', clickable
+    """
+    assert has_modal_dialog(axtree_txt) is False
+
+
+def test_browsing_agent_modal_dialog_handling():
+    # Create a mock LLM
+    mock_llm = MagicMock()
+    mock_llm.format_messages_for_llm.return_value = []
+    mock_llm.completion.return_value = {
+        'choices': [{'message': {'content': 'click("489")'}}]
+    }
+
+    # Create a BrowsingAgent instance
+    agent = BrowsingAgent(mock_llm, AgentConfig())
+
+    # Import the module-level functions
+    from openhands.agenthub.browsing_agent.browsing_agent import get_system_message, get_prompt
+
+    # Verify that the system message includes modal dialog handling instructions
+    system_msg = get_system_message('test goal', 'test action space')
+    assert 'modal dialog' in system_msg
+    assert 'cookie banner' in system_msg
+    assert 'Accept All' in system_msg
+
+    # Verify that the prompt includes modal dialog example
+    prompt = get_prompt('', 'https://example.com', 'test tree', '')
+    assert 'modal dialog' in prompt
+    assert 'cookie consent' in prompt
+    assert 'Accept All' in prompt


### PR DESCRIPTION
## Problem
The browser agent gets stuck when encountering cookie banners (like on google.com) because it does not properly handle modal dialogs and hidden elements.

## Solution
- Added detection of modal dialogs in accessibility tree
- Updated prompts to prioritize handling cookie banners
- Disabled visible-only filtering to handle hidden cookie banner elements
- Added example of handling cookie banner in prompt

## Testing
Added unit tests to verify:
- Modal dialog detection function
- Proper guidance in system message and prompts
- Example handling of cookie banners

## Notes
- The agent will now prioritize handling cookie banners before attempting other actions
- Hidden elements (like cookie banner buttons) will now be visible to the agent
- Added clear examples to help the agent understand how to handle cookie banners